### PR TITLE
docs: Fix Touch ID documentation for macOS key storage

### DIFF
--- a/src/chrome/browser/nostr/MACOS_KEY_STORAGE.md
+++ b/src/chrome/browser/nostr/MACOS_KEY_STORAGE.md
@@ -9,7 +9,7 @@ The macOS implementation (`KeyStorageMac`) uses the macOS Keychain Services API 
 - OS-level security with user authentication
 - Persistence across browser restarts
 - Protection via macOS security architecture
-- Integration with Touch ID when available
+- Touch ID support via OS when keychain requires authentication
 - Automatic keychain unlocking with user login
 
 ## Architecture
@@ -114,7 +114,7 @@ macOS-specific tests verify:
 
 1. **Keychain Locking**: Keys inaccessible when keychain is locked
 2. **User Prompts**: First access requires user approval
-3. **No Biometric Auth**: Touch ID not directly integrated (OS handles it)
+3. **Touch ID**: Not directly integrated - macOS handles Touch ID authentication for keychain access when configured by the user
 4. **Migration**: No automatic migration from other storage methods
 
 ## Migration from Extensions


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #55 regarding Touch ID documentation inconsistency.

## Changes
- Updated overview section to clarify Touch ID is supported "via OS when keychain requires authentication"
- Modified limitations section to explain Touch ID is handled by macOS, not directly integrated

## Context
The original documentation had conflicting statements about Touch ID support. This PR ensures consistency by clarifying that Touch ID authentication is provided by macOS when the user has configured it for keychain access, rather than being a feature we directly implement.

Addresses: https://github.com/sandwichfarm/tungsten/pull/55#pullrequestreview-3013437508

🤖 Generated with [Claude Code](https://claude.ai/code)