### PR TITLE
[Issue D-7] Implement Dynamic Port Allocation for Streaming Server

### DIFF
--- a/memory/LLDD_Nsite_Streaming_Server.md
+++ b/memory/LLDD_Nsite_Streaming_Server.md
@@ -1,0 +1,1058 @@
+# Low Level Design Document: Nsite Streaming Server
+## Tungsten Browser - Local HTTP Server for Nsite Content Delivery
+
+### 1. Executive Summary
+
+The Nsite Streaming Server is a critical component that bridges the gap between Nostr's decentralized content and traditional browser navigation. It runs as a persistent HTTP server on a dynamically allocated port, serving nsite content with intelligent caching, background updates, and seamless integration with the browser's UI for update notifications.
+
+### 2. Core Design Challenges and Solutions
+
+#### 2.1 The Subdomain Problem
+**Challenge**: Traditional web hosting uses subdomains for site isolation (e.g., `site1.example.com`, `site2.example.com`). However, localhost cannot have subdomains, making it impossible to use `npub1xxx.localhost` for different nsites.
+
+**Solution**: Custom header injection:
+- Browser injects `X-Nsite-Pubkey: <npub>` header with every request
+- Server serves from root path: `http://localhost:8081/<resource-path>`
+- Server reads the header to determine which nsite's files to serve
+- Preserves root-relative URLs that nsites expect
+
+#### 2.2 The Collision Problem
+**Challenge**: Different nsites WILL have identical paths. Every nsite likely has:
+- `/index.html` - their home page
+- `/style.css` - their styles
+- `/script.js` - their JavaScript
+- `/about.html`, `/contact.html` - common page names
+
+Without context, the server cannot know which nsite's `/index.html` to serve.
+
+**Solution**: The `X-Nsite-Pubkey` header provides persistent context:
+- Header must be injected on initial navigation to an nsite
+- Header must persist across ALL subsequent requests (pages, resources, AJAX)
+- Header only changes when navigating to a different nsite
+- Creates virtual namespaces while serving from root
+
+#### 2.3 The Browser Integration Problem
+**Challenge**: Standard browser navigation doesn't include custom headers. When a user clicks a link from `/index.html` to `/about.html`, the browser won't automatically include the `X-Nsite-Pubkey` header.
+
+**Solution**: Multi-layered approach to ensure header persistence:
+1. **WebRequest Interceptor**: Intercepts all requests to localhost:8081 and injects the header based on the current nsite context
+2. **Navigation State Tracker**: Maintains the current npub in browser memory, updates only when navigating to a different nsite
+3. **Session Fallback**: Server maintains session mapping as backup when headers fail
+
+#### 2.4 The Update Problem
+**Challenge**: Nostr content can be updated at any time, but checking for updates on every request would be slow.
+
+**Solution**: Dual-mode serving:
+1. Serve cached content immediately
+2. Check for updates in the background
+3. Notify user via browser banner when updates are available
+
+### 3. Detailed Architecture
+
+```cpp
+// Main server class
+class NsiteStreamingServer : public net::HttpServer::Delegate {
+ public:
+  explicit NsiteStreamingServer(Profile* profile);
+  ~NsiteStreamingServer() override;
+  
+  // Start the server on port 8081
+  bool Start();
+  void Stop();
+  
+  // HttpServer::Delegate implementation
+  void OnHttpRequest(int connection_id,
+                    const net::HttpServerRequestInfo& info) override;
+  
+ private:
+  struct RequestContext {
+    std::string npub;
+    std::string resource_path;
+    int connection_id;
+    bool is_nsite_request;
+  };
+  
+  // Request handling pipeline
+  void HandleNsiteRequest(const RequestContext& context);
+  void ServeFromCache(const RequestContext& context);
+  void CheckForUpdates(const RequestContext& context);
+  
+  // Core components
+  std::unique_ptr<net::HttpServer> http_server_;
+  std::unique_ptr<NsiteCacheManager> cache_manager_;
+  std::unique_ptr<NsiteUpdateMonitor> update_monitor_;
+  std::unique_ptr<NsiteResolver> nsite_resolver_;
+  
+  // Browser integration
+  Profile* profile_;
+  base::WeakPtrFactory<NsiteStreamingServer> weak_factory_{this};
+};
+```
+
+### 4. Request Parsing with Header Extraction
+
+```cpp
+NsiteStreamingServer::RequestContext ParseNsiteRequest(
+    const net::HttpServerRequestInfo& info) {
+  RequestContext context;
+  context.resource_path = info.path;
+  
+  // Extract npub from custom header
+  auto it = info.headers.find("X-Nsite-Pubkey");
+  if (it == info.headers.end()) {
+    // Try alternate header names for compatibility
+    it = info.headers.find("x-nsite-pubkey");
+    if (it == info.headers.end()) {
+      // Check for session-based context as fallback
+      context.npub = GetNpubFromSession(info);
+      context.is_nsite_request = !context.npub.empty();
+      return context;
+    }
+  }
+  
+  context.npub = it->second;
+  
+  // Validate npub format
+  if (!IsValidNpub(context.npub)) {
+    context.is_nsite_request = false;
+    return context;
+  }
+  
+  // Normalize path - ensure it starts with /
+  if (context.resource_path.empty() || context.resource_path == "/") {
+    context.resource_path = "/index.html";
+  }
+  
+  context.is_nsite_request = true;
+  return context;
+}
+
+void NsiteStreamingServer::OnHttpRequest(
+    int connection_id,
+    const net::HttpServerRequestInfo& info) {
+  // Parse the request with header extraction
+  RequestContext context = ParseNsiteRequest(info);
+  context.connection_id = connection_id;
+  
+  if (!context.is_nsite_request) {
+    // Not an nsite request or missing header
+    SendErrorResponse(connection_id, 
+                     "Missing X-Nsite-Pubkey header");
+    return;
+  }
+  
+  // Log request for debugging
+  VLOG(1) << "Nsite request: " << context.npub 
+          << " path: " << context.resource_path;
+  
+  // Handle nsite request
+  HandleNsiteRequest(context);
+}
+```
+
+### 5. Cache Manager Implementation
+
+```cpp
+class NsiteCacheManager {
+ public:
+  struct CachedFile {
+    std::vector<uint8_t> content;
+    std::string content_hash;
+    std::string mime_type;
+    base::Time cached_at;
+    base::Time last_accessed;
+    int64_t event_created_at;  // Nostr event timestamp
+  };
+  
+  struct NsiteCache {
+    std::string npub;
+    std::map<std::string, CachedFile> files;  // path -> file
+    base::Time last_update_check;
+    size_t total_size;
+  };
+  
+  // Cache operations
+  std::optional<CachedFile> GetFile(const std::string& npub,
+                                   const std::string& path);
+  
+  void StoreFile(const std::string& npub,
+                const std::string& path,
+                const CachedFile& file);
+  
+  bool HasNsite(const std::string& npub);
+  
+  // Get all cached paths for an nsite
+  std::vector<std::string> GetCachedPaths(const std::string& npub);
+  
+ private:
+  // LRU cache with size limits
+  void EnforceSizeLimit();
+  void EvictLeastRecentlyUsed();
+  
+  std::map<std::string, NsiteCache> cache_;
+  size_t max_cache_size_ = 500 * 1024 * 1024;  // 500MB
+  size_t current_size_ = 0;
+  
+  // Persistence
+  base::FilePath cache_dir_;
+  void LoadFromDisk();
+  void SaveToDisk();
+};
+
+std::optional<NsiteCacheManager::CachedFile> 
+NsiteCacheManager::GetFile(const std::string& npub,
+                          const std::string& path) {
+  auto nsite_it = cache_.find(npub);
+  if (nsite_it == cache_.end()) {
+    return std::nullopt;
+  }
+  
+  auto file_it = nsite_it->second.files.find(path);
+  if (file_it == nsite_it->second.files.end()) {
+    return std::nullopt;
+  }
+  
+  // Update access time
+  file_it->second.last_accessed = base::Time::Now();
+  
+  return file_it->second;
+}
+```
+
+### 6. Request Handling Pipeline
+
+```cpp
+void NsiteStreamingServer::HandleNsiteRequest(
+    const RequestContext& context) {
+  // Step 1: Try to serve from cache
+  ServeFromCache(context);
+  
+  // Step 2: Check for updates in background
+  base::ThreadPool::PostTask(
+      FROM_HERE,
+      base::BindOnce(&NsiteStreamingServer::CheckForUpdates,
+                    weak_factory_.GetWeakPtr(),
+                    context));
+}
+
+void NsiteStreamingServer::ServeFromCache(
+    const RequestContext& context) {
+  auto cached_file = cache_manager_->GetFile(
+      context.npub, context.resource_path);
+  
+  if (cached_file.has_value()) {
+    // Serve the cached file
+    SendHttpResponse(context.connection_id,
+                    net::HTTP_OK,
+                    cached_file->mime_type,
+                    cached_file->content);
+  } else {
+    // Not in cache, need to fetch
+    FetchAndServe(context);
+  }
+}
+
+void NsiteStreamingServer::FetchAndServe(
+    const RequestContext& context) {
+  // Decode npub to hex pubkey
+  std::string pubkey = DecodeNpub(context.npub);
+  
+  // Fetch the file using NsiteResolver
+  nsite_resolver_->ResolveFile(
+      pubkey,
+      context.resource_path,
+      base::BindOnce(&NsiteStreamingServer::OnFileFetched,
+                    weak_factory_.GetWeakPtr(),
+                    context));
+}
+
+void NsiteStreamingServer::OnFileFetched(
+    const RequestContext& context,
+    bool success,
+    std::unique_ptr<FileContent> content) {
+  if (!success || !content) {
+    // Try 404.html
+    if (context.resource_path != "/404.html") {
+      RequestContext not_found_context = context;
+      not_found_context.resource_path = "/404.html";
+      HandleNsiteRequest(not_found_context);
+      return;
+    }
+    
+    // No 404.html either, send generic 404
+    Send404Response(context.connection_id);
+    return;
+  }
+  
+  // Cache the file
+  NsiteCacheManager::CachedFile cached_file;
+  cached_file.content = std::move(content->data);
+  cached_file.content_hash = content->hash;
+  cached_file.mime_type = content->mime_type;
+  cached_file.cached_at = base::Time::Now();
+  cached_file.event_created_at = content->event_timestamp;
+  
+  cache_manager_->StoreFile(context.npub,
+                           context.resource_path,
+                           cached_file);
+  
+  // Serve the file
+  SendHttpResponse(context.connection_id,
+                  net::HTTP_OK,
+                  cached_file.mime_type,
+                  cached_file.content);
+}
+```
+
+### 7. Update Monitoring System
+
+```cpp
+class NsiteUpdateMonitor {
+ public:
+  struct UpdateInfo {
+    std::string npub;
+    std::string path;
+    std::string new_hash;
+    int64_t new_timestamp;
+    bool update_available;
+  };
+  
+  using UpdateCallback = base::OnceCallback<void(const UpdateInfo&)>;
+  
+  void CheckForUpdates(const std::string& npub,
+                      const std::string& path,
+                      int64_t cached_timestamp,
+                      UpdateCallback callback);
+  
+  // Batch update checking for efficiency
+  void CheckMultipleFiles(const std::string& npub,
+                         const std::map<std::string, int64_t>& files,
+                         UpdateCallback callback);
+  
+ private:
+  // Rate limiting to prevent overwhelming relays
+  bool ShouldCheckNow(const std::string& npub);
+  void RecordCheck(const std::string& npub);
+  
+  std::map<std::string, base::Time> last_check_times_;
+  base::TimeDelta min_check_interval_ = base::Minutes(5);
+};
+
+void NsiteStreamingServer::CheckForUpdates(
+    const RequestContext& context) {
+  // Get current cached file info
+  auto cached_file = cache_manager_->GetFile(
+      context.npub, context.resource_path);
+  
+  if (!cached_file.has_value()) {
+    return;  // Nothing to update
+  }
+  
+  // Check if we should rate limit
+  if (!update_monitor_->ShouldCheckNow(context.npub)) {
+    return;
+  }
+  
+  // Check for updates
+  update_monitor_->CheckForUpdates(
+      context.npub,
+      context.resource_path,
+      cached_file->event_created_at,
+      base::BindOnce(&NsiteStreamingServer::OnUpdateCheckComplete,
+                    weak_factory_.GetWeakPtr(),
+                    context));
+}
+
+void NsiteStreamingServer::OnUpdateCheckComplete(
+    const RequestContext& context,
+    const NsiteUpdateMonitor::UpdateInfo& update_info) {
+  if (!update_info.update_available) {
+    return;  // No update needed
+  }
+  
+  // Download the updated file in background
+  DownloadUpdate(context, update_info);
+  
+  // Notify the browser to show update banner
+  NotifyBrowserOfUpdate(context.npub, context.resource_path);
+}
+```
+
+### 8. Browser Integration for Update Notifications
+
+```cpp
+class NsiteUpdateNotifier {
+ public:
+  explicit NsiteUpdateNotifier(Profile* profile);
+  
+  // Notify browser of available update
+  void NotifyUpdate(const std::string& npub,
+                   const std::string& path);
+  
+  // Clear notification when user reloads
+  void ClearNotification(const std::string& npub);
+  
+ private:
+  // IPC to browser process
+  void SendUpdateMessage(const std::string& npub,
+                        const UpdateStatus& status);
+  
+  Profile* profile_;
+  std::map<std::string, UpdateStatus> pending_updates_;
+};
+
+void NsiteStreamingServer::NotifyBrowserOfUpdate(
+    const std::string& npub,
+    const std::string& path) {
+  // Get the tab that's viewing this nsite
+  content::WebContents* web_contents = 
+      FindWebContentsForNsite(npub);
+  
+  if (!web_contents) {
+    return;  // No active tab viewing this nsite
+  }
+  
+  // Inject JavaScript to show update banner
+  std::string script = base::StringPrintf(R"(
+    (function() {
+      // Create or update the banner
+      let banner = document.getElementById('nsite-update-banner');
+      if (!banner) {
+        banner = document.createElement('div');
+        banner.id = 'nsite-update-banner';
+        banner.style.cssText = `
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          background: #f0ad4e;
+          color: #333;
+          padding: 10px;
+          text-align: center;
+          z-index: 999999;
+          font-family: system-ui, sans-serif;
+          box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        `;
+        
+        banner.innerHTML = `
+          <span>A new version of this nsite is available.</span>
+          <button onclick="location.reload()" style="
+            margin-left: 10px;
+            padding: 5px 15px;
+            background: #333;
+            color: white;
+            border: none;
+            border-radius: 3px;
+            cursor: pointer;
+          ">Reload</button>
+          <button onclick="this.parentElement.remove()" style="
+            margin-left: 5px;
+            padding: 5px 10px;
+            background: transparent;
+            border: 1px solid #333;
+            border-radius: 3px;
+            cursor: pointer;
+          ">Dismiss</button>
+        `;
+        
+        document.body.appendChild(banner);
+      }
+      
+      // Auto-hide after 30 seconds
+      setTimeout(() => {
+        if (banner && banner.parentElement) {
+          banner.remove();
+        }
+      }, 30000);
+    })();
+  )", npub.c_str());
+  
+  web_contents->GetMainFrame()->ExecuteJavaScript(
+      base::UTF8ToUTF16(script),
+      base::NullCallback());
+}
+```
+
+### 9. HTTP Response Handling
+
+```cpp
+void NsiteStreamingServer::SendHttpResponse(
+    int connection_id,
+    net::HttpStatusCode status_code,
+    const std::string& mime_type,
+    const std::vector<uint8_t>& content) {
+  // Build response headers
+  std::string headers = base::StringPrintf(
+      "HTTP/1.1 %d %s\r\n"
+      "Content-Type: %s\r\n"
+      "Content-Length: %zu\r\n"
+      "Cache-Control: public, max-age=3600\r\n"
+      "Access-Control-Allow-Origin: *\r\n"
+      "\r\n",
+      status_code,
+      net::GetHttpReasonPhrase(status_code),
+      mime_type.c_str(),
+      content.size());
+  
+  // Send headers
+  http_server_->SendRaw(connection_id, headers);
+  
+  // Send body
+  if (!content.empty()) {
+    http_server_->SendRaw(
+        connection_id,
+        std::string(content.begin(), content.end()));
+  }
+  
+  // Close connection
+  http_server_->Close(connection_id);
+}
+
+void NsiteStreamingServer::Send404Response(int connection_id) {
+  const char kNotFoundHTML[] = R"(
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>404 - Nsite Not Found</title>
+      <style>
+        body {
+          font-family: system-ui, -apple-system, sans-serif;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          height: 100vh;
+          margin: 0;
+          background: #f5f5f5;
+        }
+        .error-container {
+          text-align: center;
+          padding: 40px;
+          background: white;
+          border-radius: 8px;
+          box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h1 { color: #e74c3c; margin-bottom: 10px; }
+        p { color: #666; }
+      </style>
+    </head>
+    <body>
+      <div class="error-container">
+        <h1>404</h1>
+        <p>Nsite not found or resource unavailable</p>
+      </div>
+    </body>
+    </html>
+  )";
+  
+  SendHttpResponse(connection_id,
+                  net::HTTP_NOT_FOUND,
+                  "text/html",
+                  std::vector<uint8_t>(kNotFoundHTML,
+                                      kNotFoundHTML + strlen(kNotFoundHTML)));
+}
+```
+
+### 10. Dynamic Port Management and Server Lifecycle
+
+```cpp
+class NsiteStreamingServer : public net::HttpServer::Delegate {
+ public:
+  // Port range for dynamic allocation
+  static constexpr int kMinPort = 49152;  // Start of dynamic/private port range
+  static constexpr int kMaxPort = 65535;  // End of port range
+  
+  // Ports to avoid (common development servers)
+  static const std::set<int> kAvoidPorts;
+  
+  // Get the current server port (0 if not running)
+  int GetPort() const { return current_port_; }
+  
+  // Start server with dynamic port allocation
+  bool Start();
+  
+ private:
+  int current_port_ = 0;
+  bool TryBindToPort(int port);
+};
+
+// Define ports to avoid
+const std::set<int> NsiteStreamingServer::kAvoidPorts = {
+  3000,   // React dev server
+  3001,   // Create React App fallback
+  4200,   // Angular dev server
+  5000,   // Flask default
+  5173,   // Vite
+  8000,   // Python http.server
+  8080,   // Common HTTP alternate
+  8081,   // Common HTTP alternate
+  8888,   // Jupyter
+  9000,   // PHP-FPM
+  9090,   // Prometheus
+  9200,   // Elasticsearch
+  27017,  // MongoDB
+};
+
+bool NsiteStreamingServer::Start() {
+  // Try to find an available port
+  bool bound = false;
+  
+  // First, try a random port in the range
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(kMinPort, kMaxPort);
+  
+  // Try random ports up to 10 times
+  for (int attempts = 0; attempts < 10; ++attempts) {
+    int port = dis(gen);
+    
+    // Skip if in avoid list
+    if (kAvoidPorts.find(port) != kAvoidPorts.end()) {
+      continue;
+    }
+    
+    if (TryBindToPort(port)) {
+      current_port_ = port;
+      bound = true;
+      break;
+    }
+  }
+  
+  // If random selection failed, scan sequentially
+  if (!bound) {
+    for (int port = kMinPort; port <= kMaxPort; ++port) {
+      // Skip avoided ports
+      if (kAvoidPorts.find(port) != kAvoidPorts.end()) {
+        continue;
+      }
+      
+      if (TryBindToPort(port)) {
+        current_port_ = port;
+        bound = true;
+        break;
+      }
+    }
+  }
+  
+  if (!bound) {
+    LOG(ERROR) << "Failed to find available port for Nsite server";
+    return false;
+  }
+  
+  // Initialize components
+  cache_manager_ = std::make_unique<NsiteCacheManager>(
+      profile_->GetPath().Append("NsiteCache"));
+  
+  update_monitor_ = std::make_unique<NsiteUpdateMonitor>();
+  
+  nsite_resolver_ = std::make_unique<NsiteResolver>(
+      profile_->GetURLLoaderFactory());
+  
+  // Register port with browser service
+  NsiteService::GetInstance()->SetServerPort(current_port_);
+  
+  LOG(INFO) << "Nsite streaming server started on localhost:" << current_port_;
+  return true;
+}
+
+bool NsiteStreamingServer::TryBindToPort(int port) {
+  std::unique_ptr<net::ServerSocketFactory> factory(
+      new net::TCPServerSocketFactory());
+  
+  std::unique_ptr<net::ServerSocket> server_socket =
+      factory->CreateAndListen("127.0.0.1", port);
+  
+  if (!server_socket) {
+    VLOG(2) << "Port " << port << " is not available";
+    return false;
+  }
+  
+  // Successfully bound, create HTTP server
+  http_server_ = std::make_unique<net::HttpServer>(
+      std::move(server_socket), this);
+  
+  return true;
+}
+
+void NsiteStreamingServer::Stop() {
+  if (http_server_) {
+    http_server_.reset();
+  }
+  
+  // Unregister port
+  if (current_port_ != 0) {
+    NsiteService::GetInstance()->SetServerPort(0);
+    current_port_ = 0;
+  }
+  
+  // Save cache to disk
+  if (cache_manager_) {
+    cache_manager_->SaveToDisk();
+  }
+  
+  LOG(INFO) << "Nsite streaming server stopped";
+}
+
+// Browser service to track server port
+class NsiteService : public KeyedService {
+ public:
+  static NsiteService* GetInstance();
+  
+  void SetServerPort(int port) {
+    base::AutoLock lock(port_lock_);
+    server_port_ = port;
+    
+    // Notify observers
+    for (auto& observer : observers_) {
+      observer.OnServerPortChanged(port);
+    }
+  }
+  
+  int GetServerPort() {
+    base::AutoLock lock(port_lock_);
+    return server_port_;
+  }
+  
+  // Observer interface for port changes
+  class Observer {
+   public:
+    virtual void OnServerPortChanged(int new_port) = 0;
+  };
+  
+  void AddObserver(Observer* observer);
+  void RemoveObserver(Observer* observer);
+  
+ private:
+  int server_port_ = 0;
+  base::Lock port_lock_;
+  base::ObserverList<Observer> observers_;
+}
+```
+
+### 11. Browser-Side Header Injection System
+
+The browser must ensure the `X-Nsite-Pubkey` header is included in EVERY request to localhost:8081. This is critical because different nsites have conflicting paths.
+
+```cpp
+// Browser-side component that tracks current nsite context
+class NsiteNavigationContext : public content::WebContentsObserver {
+ public:
+  explicit NsiteNavigationContext(content::WebContents* web_contents);
+  
+  // Set when initially navigating to an nsite
+  void SetCurrentNsite(const std::string& npub);
+  
+  // Get current nsite for header injection
+  std::string GetCurrentNsite() const { return current_npub_; }
+  
+  // WebContentsObserver overrides
+  void DidStartNavigation(
+      content::NavigationHandle* navigation_handle) override;
+  
+ private:
+  std::string current_npub_;
+  bool is_nsite_active_ = false;
+};
+
+// WebRequest interceptor to inject headers
+class NsiteHeaderInjector {
+ public:
+  explicit NsiteHeaderInjector(Profile* profile);
+  
+  void OnBeforeRequest(
+      const network::ResourceRequest& request,
+      OnBeforeRequestCallback callback);
+  
+  void OnBeforeSendHeaders(
+      const network::ResourceRequest& request,
+      net::HttpRequestHeaders* headers,
+      OnBeforeSendHeadersCallback callback);
+  
+ private:
+  // Get the npub for the current tab
+  std::string GetNpubForRequest(const network::ResourceRequest& request);
+  
+  // Map of tab ID to current npub
+  std::map<int, std::string> tab_npub_map_;
+  Profile* profile_;
+};
+
+void NsiteHeaderInjector::OnBeforeSendHeaders(
+    const network::ResourceRequest& request,
+    net::HttpRequestHeaders* headers,
+    OnBeforeSendHeadersCallback callback) {
+  // Get current server port
+  int server_port = NsiteService::GetInstance()->GetServerPort();
+  if (server_port == 0) {
+    // Server not running
+    std::move(callback).Run(net::OK, std::nullopt);
+    return;
+  }
+  
+  // Only inject for localhost:<dynamic-port> requests
+  if (request.url.host() != "127.0.0.1" || 
+      request.url.port() != server_port) {
+    std::move(callback).Run(net::OK, std::nullopt);
+    return;
+  }
+  
+  // Get npub for this request's tab
+  std::string npub = GetNpubForRequest(request);
+  if (npub.empty()) {
+    // No nsite context, let request proceed without header
+    std::move(callback).Run(net::OK, std::nullopt);
+    return;
+  }
+  
+  // Inject the header
+  headers->SetHeader("X-Nsite-Pubkey", npub);
+  
+  VLOG(2) << "Injected X-Nsite-Pubkey: " << npub 
+          << " for " << request.url.path();
+  
+  std::move(callback).Run(net::OK, std::nullopt);
+}
+
+// Navigation tracking to update context
+void NsiteNavigationContext::DidStartNavigation(
+    content::NavigationHandle* navigation_handle) {
+  if (!navigation_handle->IsInMainFrame()) {
+    return;  // Only track main frame navigations
+  }
+  
+  GURL url = navigation_handle->GetURL();
+  
+  // Check if this is a navigation to a different nsite
+  if (url.scheme() == "nostr" && url.host() == "nsite") {
+    // Extract new npub from the nostr:// URL
+    std::string new_npub = ExtractNpubFromNostrUrl(url);
+    if (new_npub != current_npub_) {
+      LOG(INFO) << "Switching nsite context from " 
+                << current_npub_ << " to " << new_npub;
+      SetCurrentNsite(new_npub);
+    }
+  }
+  
+  // If navigating away from localhost:<server-port>, clear context
+  int server_port = NsiteService::GetInstance()->GetServerPort();
+  if (is_nsite_active_ && server_port > 0 &&
+      (url.host() != "127.0.0.1" || url.port() != server_port)) {
+    LOG(INFO) << "Leaving nsite context";
+    current_npub_.clear();
+    is_nsite_active_ = false;
+  }
+}
+```
+
+### 12. Protocol Handler Integration
+
+The nostr:// protocol handler must be updated to redirect to the streaming server and set up the navigation context:
+
+```cpp
+void NostrProtocolHandler::HandleNsiteUrl(
+    const GURL& url,
+    content::WebContents* web_contents) {
+  // Parse the nsite URL
+  // Format: nostr://nsite/<identifier>/<path>
+  std::string path = url.path();
+  if (base::StartsWith(path, "/")) {
+    path = path.substr(1);
+  }
+  
+  // Extract identifier and resource path
+  size_t slash_pos = path.find('/');
+  std::string identifier;
+  std::string resource_path = "/";
+  
+  if (slash_pos != std::string::npos) {
+    identifier = path.substr(0, slash_pos);
+    resource_path = path.substr(slash_pos);
+  } else {
+    identifier = path;
+  }
+  
+  // Resolve identifier to npub if needed
+  std::string npub;
+  if (base::StartsWith(identifier, "npub1")) {
+    npub = identifier;
+  } else {
+    // Use NsiteResolver to resolve NIP-05 or domain
+    // For now, we'll handle this synchronously
+    npub = ResolveToNpub(identifier);
+    if (npub.empty()) {
+      ShowErrorPage(web_contents, "Failed to resolve: " + identifier);
+      return;
+    }
+  }
+  
+  // CRITICAL: Set up the navigation context BEFORE redirecting
+  auto* context = NsiteNavigationContext::FromWebContents(web_contents);
+  if (!context) {
+    context = NsiteNavigationContext::CreateForWebContents(web_contents);
+  }
+  context->SetCurrentNsite(npub);
+  
+  // Register this tab with the header injector
+  NsiteHeaderInjector::GetInstance()->RegisterTab(
+      web_contents->GetMainFrame()->GetProcess()->GetID(),
+      web_contents->GetMainFrame()->GetRoutingID(),
+      npub);
+  
+  // Get current server port
+  int server_port = NsiteService::GetInstance()->GetServerPort();
+  if (server_port == 0) {
+    // Server not running, try to start it
+    if (!NsiteService::GetInstance()->EnsureServerRunning()) {
+      ShowErrorPage(web_contents, "Failed to start Nsite server");
+      return;
+    }
+    server_port = NsiteService::GetInstance()->GetServerPort();
+  }
+  
+  // Build localhost URL (serves from root!)
+  GURL redirect_url(base::StringPrintf(
+      "http://localhost:%d%s",
+      server_port,
+      resource_path.c_str()));
+  
+  LOG(INFO) << "Navigating to nsite: " << npub 
+            << " at path: " << resource_path
+            << " on port: " << server_port;
+  
+  // Redirect the navigation
+  content::NavigationController::LoadURLParams params(redirect_url);
+  params.transition_type = ui::PAGE_TRANSITION_AUTO_BOOKMARK;
+  
+  // Add referrer to help server track context as fallback
+  params.referrer = content::Referrer(
+      GURL("nostr://nsite/" + npub),
+      network::mojom::ReferrerPolicy::kDefault);
+  
+  web_contents->GetController().LoadURLWithParams(params);
+}
+```
+
+### 12. Performance Optimizations
+
+```cpp
+class NsitePreloader {
+ public:
+  // Preload common resources when user hovers over link
+  void PreloadNsite(const std::string& npub);
+  
+  // Batch fetch multiple files
+  void BatchFetchFiles(const std::string& npub,
+                      const std::vector<std::string>& paths);
+  
+ private:
+  // Smart preloading based on typical web patterns
+  std::vector<std::string> PredictResources(
+      const std::string& initial_path);
+};
+
+std::vector<std::string> NsitePreloader::PredictResources(
+    const std::string& initial_path) {
+  std::vector<std::string> resources;
+  
+  if (initial_path == "/" || initial_path == "/index.html") {
+    // Common resources for home page
+    resources.push_back("/style.css");
+    resources.push_back("/script.js");
+    resources.push_back("/favicon.ico");
+    resources.push_back("/manifest.json");
+  }
+  
+  return resources;
+}
+```
+
+### 13. Security Considerations
+
+1. **Port Security**: Bind only to localhost (127.0.0.1) to prevent external access
+2. **Path Traversal**: Sanitize all paths to prevent directory traversal attacks
+3. **Content Validation**: Always verify content hashes before serving
+4. **CORS Headers**: Set appropriate CORS headers for browser compatibility
+5. **Request Limits**: Implement rate limiting to prevent DoS
+
+```cpp
+bool NsiteStreamingServer::IsPathSafe(const std::string& path) {
+  // Prevent directory traversal
+  if (path.find("..") != std::string::npos) {
+    return false;
+  }
+  
+  // Ensure absolute paths
+  if (!base::StartsWith(path, "/")) {
+    return false;
+  }
+  
+  // Prevent access to hidden files
+  if (path.find("/.") != std::string::npos) {
+    return false;
+  }
+  
+  return true;
+}
+```
+
+### 14. Error Handling and Recovery
+
+```cpp
+class NsiteErrorHandler {
+ public:
+  enum ErrorType {
+    NETWORK_ERROR,
+    INVALID_CONTENT,
+    RELAY_TIMEOUT,
+    BLOSSOM_UNAVAILABLE,
+    CACHE_CORRUPTION
+  };
+  
+  void HandleError(ErrorType error,
+                  const RequestContext& context);
+  
+ private:
+  void LogError(ErrorType error, const std::string& details);
+  void ServeErrorPage(int connection_id, ErrorType error);
+};
+```
+
+### 15. Monitoring and Diagnostics
+
+```cpp
+class NsiteServerMetrics {
+ public:
+  void RecordRequest(const std::string& npub,
+                    const std::string& path,
+                    bool cache_hit);
+  
+  void RecordUpdateCheck(const std::string& npub,
+                        bool update_found);
+  
+  void RecordError(NsiteErrorHandler::ErrorType error);
+  
+  // Get metrics for chrome://nsite-internals
+  base::Value GetMetricsSnapshot();
+  
+ private:
+  struct Metrics {
+    int64_t total_requests = 0;
+    int64_t cache_hits = 0;
+    int64_t cache_misses = 0;
+    int64_t update_checks = 0;
+    int64_t updates_found = 0;
+    std::map<int, int64_t> error_counts;
+  };
+  
+  Metrics metrics_;
+  base::Lock metrics_lock_;
+};
+```
+
+### 16. Future Enhancements
+
+1. **WebSocket Support**: For real-time nsite features
+2. **Service Worker**: Enable offline functionality
+3. **P2P Sharing**: Share cached nsites between local Tungsten instances
+4. **Compression**: Support gzip/brotli for bandwidth efficiency
+5. **Partial Updates**: Only download changed files
+6. **CDN Integration**: Optional CDN fallback for popular nsites

--- a/memory/Nsite_Streaming_Server_Issues.md
+++ b/memory/Nsite_Streaming_Server_Issues.md
@@ -1,0 +1,304 @@
+# Nsite Streaming Server Issues
+
+Following Tungsten's issue creation template for Group D (Protocol Handlers).
+
+---
+
+## Issue Title: D-7: Implement Dynamic Port Allocation for Streaming Server
+
+### Context
+- **Group**: D (Protocol Handlers)
+- **Dependencies**: D-4 (#24)
+- **Milestone**: M4: Protocol Support
+
+### Description
+Implement dynamic port allocation for the Nsite streaming server in the ephemeral port range (49152-65535), avoiding common development ports. The server must communicate its port to browser components for proper request routing.
+
+### Acceptance Criteria
+- [ ] Server successfully binds to available port in range 49152-65535
+- [ ] Avoids common development ports (3000, 8080, 5173, etc.)
+- [ ] Falls back to sequential scan if random selection fails
+- [ ] Port is accessible via NsiteService singleton
+- [ ] Tests written for port allocation logic
+- [ ] Documentation updated
+
+### Technical Notes
+- Key files to create: `nsite_streaming_server.h/cc`, `nsite_service.h/cc`
+- Use `net::ServerSocket` for binding attempts
+- Implement retry logic with both random and sequential strategies
+- Thread-safe port storage in NsiteService
+
+### References
+- Related LLDDs: /memory/LLDD_Nsite_Streaming_Server.md
+- Related specs: Dynamic port allocation (Section 10)
+
+---
+
+## Issue Title: D-8: Implement Header-Based Request Routing
+
+### Context
+- **Group**: D (Protocol Handlers)
+- **Dependencies**: D-7
+- **Milestone**: M4: Protocol Support
+
+### Description
+Implement request parsing and routing based on X-Nsite-Pubkey header. The server must extract the npub from the header to determine which nsite's files to serve, as different nsites will have conflicting paths like /index.html.
+
+### Acceptance Criteria
+- [ ] Parse X-Nsite-Pubkey header from incoming requests
+- [ ] Validate npub format
+- [ ] Route requests to correct nsite namespace
+- [ ] Handle missing/invalid headers gracefully
+- [ ] Support case-insensitive header matching
+- [ ] Tests for various header scenarios
+- [ ] Documentation updated
+
+### Technical Notes
+- Implement in `NsiteStreamingServer::ParseNsiteRequest()`
+- Return structured RequestContext with npub and path
+- Log all requests for debugging
+- Consider session-based fallback for missing headers
+
+### References
+- Related LLDDs: /memory/LLDD_Nsite_Streaming_Server.md
+- Header injection design (Section 4)
+
+---
+
+## Issue Title: D-9: Implement Nsite Cache Manager
+
+### Context
+- **Group**: D (Protocol Handlers)
+- **Dependencies**: D-8
+- **Milestone**: M4: Protocol Support
+
+### Description
+Build the caching system for nsite files with LRU eviction, persistence, and efficient lookup. Cache must handle multiple nsites with conflicting paths by namespacing with npub.
+
+### Acceptance Criteria
+- [ ] Store files indexed by npub + path
+- [ ] Implement LRU eviction at 500MB limit
+- [ ] Track cache hits/misses and access times
+- [ ] Thread-safe cache operations
+- [ ] Persist cache metadata to disk
+- [ ] Restore cache on server startup
+- [ ] Unit tests for cache operations
+- [ ] Documentation updated
+
+### Technical Notes
+- Create `nsite_cache_manager.h/cc`
+- Use profile directory for persistence
+- Implement CachedFile structure with metadata
+- Consider memory-mapped files for large content
+
+### References
+- Related LLDDs: /memory/LLDD_Nsite_Streaming_Server.md
+- Cache implementation (Section 5)
+
+---
+
+## Issue Title: D-10: Implement Browser Header Injection System
+
+### Context
+- **Group**: D (Protocol Handlers)
+- **Dependencies**: D-7, D-8
+- **Milestone**: M4: Protocol Support
+
+### Description
+Implement WebRequest interceptor to inject X-Nsite-Pubkey header for all requests to the streaming server. Critical for maintaining nsite context across page navigations.
+
+### Acceptance Criteria
+- [ ] Intercept all requests to localhost:<dynamic-port>
+- [ ] Inject header based on current tab's nsite context
+- [ ] Handle subframes and resources correctly
+- [ ] Maintain header across all navigations within same nsite
+- [ ] Clear header when navigating to different nsite
+- [ ] Integration tests for header persistence
+- [ ] Documentation updated
+
+### Technical Notes
+- Create `nsite_header_injector.h/cc`
+- Use content::WebRequestAPI
+- Implement NsiteNavigationContext as WebContentsObserver
+- Cache tab-to-npub mappings for performance
+
+### References
+- Related LLDDs: /memory/LLDD_Nsite_Streaming_Server.md
+- Browser integration (Section 11)
+
+---
+
+## Issue Title: D-11: Update Protocol Handler for Streaming Server
+
+### Context
+- **Group**: D (Protocol Handlers)
+- **Dependencies**: D-10
+- **Milestone**: M4: Protocol Support
+
+### Description
+Update the nostr:// protocol handler to redirect nsite URLs to the streaming server with proper context setup. Must query dynamic port and establish navigation context before redirect.
+
+### Acceptance Criteria
+- [ ] Resolve nsite identifier to npub (support NIP-05)
+- [ ] Query NsiteService for current server port
+- [ ] Start server if not running
+- [ ] Set up navigation context before redirect
+- [ ] Redirect to localhost:<port>/<path>
+- [ ] Handle resolution failures gracefully
+- [ ] Integration tests for full flow
+- [ ] Documentation updated
+
+### Technical Notes
+- Modify `nostr_protocol_handler.cc`
+- Add async identifier resolution
+- Show loading/error states
+- Set referrer header as fallback
+
+### References
+- Related LLDDs: /memory/LLDD_Nsite_Streaming_Server.md
+- Protocol handler updates (Section 12)
+
+---
+
+## Issue Title: D-12: Implement Background Update Monitor
+
+### Context
+- **Group**: D (Protocol Handlers)
+- **Dependencies**: D-9
+- **Milestone**: M4: Protocol Support
+
+### Description
+Implement background checking for nsite updates after serving cached content. Must not block request serving and should notify users when updates are available.
+
+### Acceptance Criteria
+- [ ] Check for updates after serving from cache
+- [ ] Rate limit checks to minimum 5 minutes per nsite
+- [ ] Compare event timestamps to detect updates
+- [ ] Download changed files in background
+- [ ] Don't interrupt active user session
+- [ ] Tests for update detection logic
+- [ ] Documentation updated
+
+### Technical Notes
+- Create `nsite_update_monitor.h/cc`
+- Use base::ThreadPool for background work
+- Track last check time per nsite
+- Implement progressive download
+
+### References
+- Related LLDDs: /memory/LLDD_Nsite_Streaming_Server.md
+- Update monitoring (Section 7)
+
+---
+
+## Issue Title: D-13: Implement Update Notification Banner
+
+### Context
+- **Group**: D (Protocol Handlers)
+- **Dependencies**: D-12
+- **Milestone**: M4: Protocol Support
+
+### Description
+Show non-intrusive banner to users when nsite updates are available, allowing them to reload when ready.
+
+### Acceptance Criteria
+- [ ] Inject banner via JavaScript into active tab
+- [ ] Include reload and dismiss buttons
+- [ ] Auto-hide after 30 seconds
+- [ ] Styled to match browser theme
+- [ ] Only show for visible tabs
+- [ ] E2E tests for notification flow
+- [ ] Documentation updated
+
+### Technical Notes
+- Use WebContents::ExecuteJavaScript()
+- Store dismissed state per nsite
+- Position fixed at top of viewport
+- Ensure accessibility compliance
+
+### References
+- Related LLDDs: /memory/LLDD_Nsite_Streaming_Server.md
+- Update notifications (Section 8)
+
+---
+
+## Issue Title: D-14: Implement Security Hardening
+
+### Context
+- **Group**: D (Protocol Handlers)
+- **Dependencies**: D-7 through D-13
+- **Milestone**: M4: Protocol Support
+
+### Description
+Security audit and hardening of the streaming server to prevent attacks and ensure safe operation.
+
+### Acceptance Criteria
+- [ ] Path traversal prevention implemented
+- [ ] Input validation for all parameters
+- [ ] Rate limiting for requests
+- [ ] Secure session handling
+- [ ] No information leakage in errors
+- [ ] Security tests written
+- [ ] Documentation updated
+
+### Technical Notes
+- Implement IsPathSafe() validation
+- Sanitize all user inputs
+- Use constant-time comparisons where needed
+- Structured error responses
+
+### References
+- Related LLDDs: /memory/LLDD_Nsite_Streaming_Server.md
+- Security considerations (Section 13)
+
+---
+
+## Issue Title: D-15: Performance Optimization and Monitoring
+
+### Context
+- **Group**: D (Protocol Handlers)
+- **Dependencies**: D-7 through D-13
+- **Milestone**: M4: Protocol Support
+
+### Description
+Optimize streaming server performance and add monitoring capabilities for debugging and metrics.
+
+### Acceptance Criteria
+- [ ] Cache hits under 100ms
+- [ ] Server startup under 500ms
+- [ ] Memory usage under 100MB for 10 nsites
+- [ ] CPU usage near 0% when idle
+- [ ] Metrics accessible via chrome://nsite-internals
+- [ ] Performance tests written
+- [ ] Documentation updated
+
+### Technical Notes
+- Profile with Chrome tracing
+- Add UMA metrics for monitoring
+- Implement chrome://nsite-internals page
+- Consider memory mapping for large files
+
+### References
+- Related LLDDs: /memory/LLDD_Nsite_Streaming_Server.md
+- Performance targets (Section 15)
+
+---
+
+## Implementation Priority
+
+Based on dependencies:
+1. D-7 (Dynamic Port) - Foundation
+2. D-8 (Request Routing) - Core functionality
+3. D-9 (Cache Manager) - Essential for performance
+4. D-10 & D-11 (Browser Integration) - Can be done in parallel
+5. D-12 & D-13 (Updates) - Enhancement
+6. D-14 (Security) - Critical before release
+7. D-15 (Performance) - Polish
+
+## Testing Strategy
+
+- Unit tests for each component
+- Integration tests for full request flow
+- E2E tests for user scenarios
+- Security tests for vulnerabilities
+- Performance benchmarks against targets

--- a/memory/Nsite_Streaming_Server_Milestones_Issues.md
+++ b/memory/Nsite_Streaming_Server_Milestones_Issues.md
@@ -1,0 +1,424 @@
+# Nsite Streaming Server - Milestones and Issues
+
+## Overview
+Implementation of a local HTTP streaming server that serves Nsite content with dynamic port allocation, intelligent caching, and seamless browser integration.
+
+## Milestones
+
+### M1: Core Server Infrastructure
+**Goal**: Establish the basic HTTP server with dynamic port allocation
+**Duration**: 1 week
+
+### M2: Request Routing and Header Processing
+**Goal**: Implement header-based nsite identification and request routing
+**Duration**: 1 week
+
+### M3: Cache Management System
+**Goal**: Build the caching layer for nsite content
+**Duration**: 1 week
+
+### M4: Browser Integration
+**Goal**: Implement browser-side header injection and navigation context
+**Duration**: 2 weeks
+
+### M5: Update Monitoring and Notifications
+**Goal**: Add background update checking and user notifications
+**Duration**: 1 week
+
+### M6: Testing and Polish
+**Goal**: Comprehensive testing, error handling, and performance optimization
+**Duration**: 1 week
+
+---
+
+## Issues by Milestone
+
+### M1: Core Server Infrastructure
+
+#### Issue S-1: Dynamic Port Allocation System
+**Dependencies**: None
+**Priority**: Critical
+**Description**: Implement dynamic port allocation in the ephemeral range (49152-65535)
+
+**Acceptance Criteria**:
+- [ ] Server tries random ports first, then sequential scan
+- [ ] Avoids common development ports (3000, 8080, etc.)
+- [ ] Handles bind failures gracefully
+- [ ] Persists chosen port for session
+
+**Technical Notes**:
+- Use `net::ServerSocket` for binding attempts
+- Implement in `NsiteStreamingServer::TryBindToPort()`
+- Store avoided ports in static set
+
+---
+
+#### Issue S-2: NsiteService Port Management
+**Dependencies**: S-1
+**Priority**: Critical
+**Description**: Create service to track and communicate server port to browser components
+
+**Acceptance Criteria**:
+- [ ] Singleton service accessible throughout browser
+- [ ] Thread-safe port getter/setter
+- [ ] Observer pattern for port change notifications
+- [ ] Auto-start server when first accessed
+
+**Technical Notes**:
+- Implement as `KeyedService`
+- Use `base::Lock` for thread safety
+- Add to `BrowserContextKeyedServiceFactory`
+
+---
+
+#### Issue S-3: Basic HTTP Server Lifecycle
+**Dependencies**: S-1, S-2
+**Priority**: High
+**Description**: Implement server start/stop with proper cleanup
+
+**Acceptance Criteria**:
+- [ ] Server starts on browser launch
+- [ ] Graceful shutdown on browser exit
+- [ ] Restart capability if server crashes
+- [ ] Logging for debugging
+
+**Technical Notes**:
+- Hook into `BrowserMainParts::PostMainMessageLoopRun()`
+- Implement crash detection and auto-restart
+
+---
+
+### M2: Request Routing and Header Processing
+
+#### Issue S-4: Request Context Parser
+**Dependencies**: S-3
+**Priority**: Critical
+**Description**: Parse incoming requests to extract npub from X-Nsite-Pubkey header
+
+**Acceptance Criteria**:
+- [ ] Extract npub from X-Nsite-Pubkey header
+- [ ] Handle missing/invalid headers gracefully
+- [ ] Support case-insensitive header names
+- [ ] Validate npub format
+
+**Technical Notes**:
+- Implement in `ParseNsiteRequest()`
+- Return structured `RequestContext`
+- Log all requests for debugging
+
+---
+
+#### Issue S-5: Path-based Request Router
+**Dependencies**: S-4
+**Priority**: High
+**Description**: Route requests to appropriate handlers based on resource path
+
+**Acceptance Criteria**:
+- [ ] Serve files from root path as nsites expect
+- [ ] Default empty path to /index.html
+- [ ] Handle 404s with fallback to /404.html
+- [ ] Prevent path traversal attacks
+
+**Technical Notes**:
+- Sanitize all paths
+- Implement `IsPathSafe()` validation
+- Use cache manager for file retrieval
+
+---
+
+#### Issue S-6: Session-based Fallback
+**Dependencies**: S-4
+**Priority**: Medium
+**Description**: Implement session tracking as fallback when headers fail
+
+**Acceptance Criteria**:
+- [ ] Map session IDs to npubs
+- [ ] Clean up stale sessions
+- [ ] Use cookies or URL parameters
+- [ ] Seamless fallback from header method
+
+**Technical Notes**:
+- Consider using referrer header
+- Implement session timeout (30 minutes)
+- Store in memory with size limits
+
+---
+
+### M3: Cache Management System
+
+#### Issue S-7: NsiteCacheManager Implementation
+**Dependencies**: S-5
+**Priority**: Critical
+**Description**: Build the core caching system for nsite files
+
+**Acceptance Criteria**:
+- [ ] Store files by npub + path
+- [ ] LRU eviction when size limit reached
+- [ ] Track access times and hit rates
+- [ ] Thread-safe operations
+
+**Technical Notes**:
+- Default cache size: 500MB
+- Use `base::FilePath` for persistence
+- Implement `CachedFile` structure
+
+---
+
+#### Issue S-8: Cache Persistence
+**Dependencies**: S-7
+**Priority**: High
+**Description**: Save and restore cache to/from disk
+
+**Acceptance Criteria**:
+- [ ] Save cache metadata on shutdown
+- [ ] Restore cache on startup
+- [ ] Verify file integrity (hashes)
+- [ ] Handle corrupted cache gracefully
+
+**Technical Notes**:
+- Store in profile directory
+- Use protobuf or JSON for metadata
+- Background save every 5 minutes
+
+---
+
+#### Issue S-9: Content Type Detection
+**Dependencies**: S-7
+**Priority**: Medium
+**Description**: Detect and set correct MIME types for responses
+
+**Acceptance Criteria**:
+- [ ] Detect common web file types
+- [ ] Support custom MIME mappings
+- [ ] Default to application/octet-stream
+- [ ] Handle text encoding properly
+
+**Technical Notes**:
+- Use `net::GetMimeTypeFromFile()`
+- Special handling for .js as text/javascript
+- UTF-8 for text files
+
+---
+
+### M4: Browser Integration
+
+#### Issue S-10: WebRequest Header Injector
+**Dependencies**: S-2
+**Priority**: Critical
+**Description**: Intercept requests to inject X-Nsite-Pubkey header
+
+**Acceptance Criteria**:
+- [ ] Intercept all requests to localhost:<port>
+- [ ] Inject header based on tab context
+- [ ] Handle frames and subresources
+- [ ] Minimal performance impact
+
+**Technical Notes**:
+- Use `content::WebRequestAPI`
+- Register in `OnBeforeSendHeaders`
+- Cache tab->npub mappings
+
+---
+
+#### Issue S-11: Navigation Context Tracker
+**Dependencies**: S-10
+**Priority**: Critical
+**Description**: Track current nsite context per tab
+
+**Acceptance Criteria**:
+- [ ] Detect navigation to new nsite
+- [ ] Maintain context across page loads
+- [ ] Clear context when leaving nsite
+- [ ] Handle tab switches correctly
+
+**Technical Notes**:
+- Implement as `WebContentsObserver`
+- Update on `DidStartNavigation`
+- Store as `WebContentsUserData`
+
+---
+
+#### Issue S-12: Protocol Handler Updates
+**Dependencies**: S-11
+**Priority**: High
+**Description**: Update nostr:// handler to use streaming server
+
+**Acceptance Criteria**:
+- [ ] Resolve nsite identifier to npub
+- [ ] Query service for current port
+- [ ] Set up navigation context
+- [ ] Redirect to localhost URL
+
+**Technical Notes**:
+- Handle async NIP-05 resolution
+- Show loading state during resolution
+- Error page for resolution failures
+
+---
+
+#### Issue S-13: Browser UI Integration
+**Dependencies**: S-12
+**Priority**: Medium
+**Description**: Add UI elements for nsite status
+
+**Acceptance Criteria**:
+- [ ] Show current nsite in omnibox
+- [ ] Indicate cache status
+- [ ] Server status in chrome://nsite-internals
+- [ ] Debug information page
+
+**Technical Notes**:
+- Extend omnibox with nsite info
+- Create new chrome:// page
+- Show cache statistics
+
+---
+
+### M5: Update Monitoring and Notifications
+
+#### Issue S-14: Background Update Checker
+**Dependencies**: S-7
+**Priority**: High
+**Description**: Check for content updates without blocking requests
+
+**Acceptance Criteria**:
+- [ ] Check after serving cached content
+- [ ] Rate limit checks (5 min minimum)
+- [ ] Compare event timestamps
+- [ ] Download only changed files
+
+**Technical Notes**:
+- Use `base::ThreadPool`
+- Implement `NsiteUpdateMonitor`
+- Track last check per nsite
+
+---
+
+#### Issue S-15: Update Notification Banner
+**Dependencies**: S-14
+**Priority**: High
+**Description**: Show banner when updates are available
+
+**Acceptance Criteria**:
+- [ ] Inject banner via JavaScript
+- [ ] Non-intrusive placement
+- [ ] Reload and dismiss buttons
+- [ ] Auto-hide after 30 seconds
+
+**Technical Notes**:
+- Use `ExecuteJavaScript()`
+- Style to match browser theme
+- Store dismissed state
+
+---
+
+#### Issue S-16: Progressive Update Downloads
+**Dependencies**: S-14
+**Priority**: Medium
+**Description**: Download updates without interrupting current session
+
+**Acceptance Criteria**:
+- [ ] Download to temporary location
+- [ ] Verify hashes before replacing
+- [ ] Atomic file replacement
+- [ ] Resume interrupted downloads
+
+**Technical Notes**:
+- Use `.tmp` extension during download
+- Implement resumable downloads
+- Clean up orphaned files
+
+---
+
+### M6: Testing and Polish
+
+#### Issue S-17: Integration Test Suite
+**Dependencies**: All previous
+**Priority**: High
+**Description**: Comprehensive integration tests
+
+**Acceptance Criteria**:
+- [ ] Test full navigation flow
+- [ ] Simulate multiple concurrent nsites
+- [ ] Test cache eviction
+- [ ] Performance benchmarks
+
+**Technical Notes**:
+- Use `content::BrowserTest`
+- Mock relay responses
+- Measure request latencies
+
+---
+
+#### Issue S-18: Error Handling and Recovery
+**Dependencies**: All previous
+**Priority**: High
+**Description**: Robust error handling throughout system
+
+**Acceptance Criteria**:
+- [ ] Graceful handling of all failures
+- [ ] User-friendly error pages
+- [ ] Automatic recovery attempts
+- [ ] Detailed error logging
+
+**Technical Notes**:
+- Custom error pages per error type
+- Exponential backoff for retries
+- Structured logging
+
+---
+
+#### Issue S-19: Performance Optimization
+**Dependencies**: S-17
+**Priority**: Medium
+**Description**: Optimize for speed and resource usage
+
+**Acceptance Criteria**:
+- [ ] Sub-100ms cache hits
+- [ ] Efficient memory usage
+- [ ] Minimal CPU when idle
+- [ ] Fast server startup
+
+**Technical Notes**:
+- Profile with Chrome tracing
+- Optimize hot paths
+- Consider memory mapping for large files
+
+---
+
+#### Issue S-20: Security Hardening
+**Dependencies**: All previous
+**Priority**: High
+**Description**: Security review and hardening
+
+**Acceptance Criteria**:
+- [ ] Prevent path traversal
+- [ ] Validate all inputs
+- [ ] Rate limiting
+- [ ] Secure session handling
+
+**Technical Notes**:
+- Security audit checklist
+- Fuzzing for edge cases
+- Penetration testing
+
+---
+
+## Implementation Order
+
+1. **Week 1**: S-1, S-2, S-3 (Core Infrastructure)
+2. **Week 2**: S-4, S-5, S-6 (Request Routing)
+3. **Week 3**: S-7, S-8, S-9 (Cache System)
+4. **Week 4**: S-10, S-11, S-12 (Browser Integration Part 1)
+5. **Week 5**: S-13, S-14, S-15 (Browser Integration Part 2 & Updates)
+6. **Week 6**: S-16, S-17 (Updates & Testing)
+7. **Week 7**: S-18, S-19, S-20 (Polish & Security)
+
+## Success Metrics
+
+- Server starts in < 500ms
+- Cache hit rate > 90% for repeat visits
+- Page load time < 200ms for cached content
+- Memory usage < 100MB for 10 active nsites
+- Zero security vulnerabilities
+- 99.9% server uptime during browser session

--- a/src/chrome/browser/nostr/BUILD.gn
+++ b/src/chrome/browser/nostr/BUILD.gn
@@ -44,6 +44,7 @@ if (enable_nostr) {
       "//ui/views",
       "//url",
       "protocol",
+      "nsite",
     ]
     
     if (is_win) {
@@ -202,6 +203,9 @@ if (enable_nostr) {
       
       # Include local relay tests
       "//chrome/browser/nostr/local_relay:local_relay_unittests",
+      
+      # Include nsite tests
+      "//chrome/browser/nostr/nsite:unit_tests",
     ]
   }
 

--- a/src/chrome/browser/nostr/nsite/BUILD.gn
+++ b/src/chrome/browser/nostr/nsite/BUILD.gn
@@ -1,0 +1,42 @@
+# Copyright 2024 The Tungsten Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/features.gni")
+
+source_set("nsite") {
+  sources = [
+    "nsite_service.cc",
+    "nsite_service.h",
+    "nsite_streaming_server.cc",
+    "nsite_streaming_server.h",
+  ]
+
+  deps = [
+    "//base",
+    "//chrome/browser/profiles",
+    "//content/public/browser",
+    "//net",
+    "//net:net_with_v8",
+    "//services/network/public/cpp",
+    "//url",
+  ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+  
+  sources = [
+    "nsite_streaming_server_unittest.cc",
+  ]
+  
+  deps = [
+    ":nsite",
+    "//base",
+    "//base/test:test_support",
+    "//chrome/browser/profiles:test_support",
+    "//content/test:test_support",
+    "//net:test_support",
+    "//testing/gtest",
+  ]
+}

--- a/src/chrome/browser/nostr/nsite/nsite_service.cc
+++ b/src/chrome/browser/nostr/nsite/nsite_service.cc
@@ -1,0 +1,126 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/nostr/nsite/nsite_service.h"
+
+#include "base/logging.h"
+#include "chrome/browser/nostr/nsite/nsite_streaming_server.h"
+#include "chrome/browser/profiles/profile.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
+
+namespace nostr {
+
+// static
+NsiteService* NsiteService::GetInstance() {
+  static base::NoDestructor<NsiteService> instance;
+  return instance.get();
+}
+
+NsiteService::NsiteService() = default;
+
+NsiteService::~NsiteService() {
+  // Stop all servers
+  base::AutoLock lock(lock_);
+  servers_.clear();
+}
+
+uint16_t NsiteService::GetOrStartServer(Profile* profile) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  DCHECK(profile);
+  
+  if (profile->IsOffTheRecord()) {
+    LOG(WARNING) << "Nsite streaming server not supported in incognito mode";
+    return 0;
+  }
+
+  base::AutoLock lock(lock_);
+  
+  // Check if server already exists for this profile
+  auto it = servers_.find(profile);
+  if (it != servers_.end() && it->second.server && it->second.server->IsRunning()) {
+    return it->second.port;
+  }
+
+  // Create new server
+  auto server = std::make_unique<NsiteStreamingServer>(profile->GetPath());
+  uint16_t port = server->Start();
+  
+  if (port == 0) {
+    LOG(ERROR) << "Failed to start nsite streaming server for profile";
+    return 0;
+  }
+
+  // Store server info
+  ServerInfo& info = servers_[profile];
+  info.server = std::move(server);
+  info.port = port;
+
+  // Notify observers
+  NotifyServerStateChange(true, port);
+  
+  LOG(INFO) << "Started nsite streaming server on port " << port;
+  return port;
+}
+
+void NsiteService::StopServer(Profile* profile) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  DCHECK(profile);
+
+  base::AutoLock lock(lock_);
+  
+  auto it = servers_.find(profile);
+  if (it == servers_.end()) {
+    return;
+  }
+
+  it->second.server.reset();
+  it->second.port = 0;
+  servers_.erase(it);
+
+  // Notify observers
+  NotifyServerStateChange(false, 0);
+  
+  LOG(INFO) << "Stopped nsite streaming server for profile";
+}
+
+uint16_t NsiteService::GetServerPort(Profile* profile) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  DCHECK(profile);
+
+  base::AutoLock lock(lock_);
+  
+  auto it = servers_.find(profile);
+  if (it != servers_.end() && it->second.server && it->second.server->IsRunning()) {
+    return it->second.port;
+  }
+  
+  return 0;
+}
+
+bool NsiteService::IsServerRunning(Profile* profile) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  DCHECK(profile);
+
+  base::AutoLock lock(lock_);
+  
+  auto it = servers_.find(profile);
+  return it != servers_.end() && it->second.server && it->second.server->IsRunning();
+}
+
+void NsiteService::AddServerStateObserver(ServerStateCallback callback) {
+  base::AutoLock lock(lock_);
+  observers_.push_back(std::move(callback));
+}
+
+void NsiteService::NotifyServerStateChange(bool running, uint16_t port) {
+  // Called with lock_ held
+  for (const auto& observer : observers_) {
+    content::GetUIThreadTaskRunner({})->PostTask(
+        FROM_HERE,
+        base::BindOnce(observer, running, port));
+  }
+}
+
+}  // namespace nostr

--- a/src/chrome/browser/nostr/nsite/nsite_service.h
+++ b/src/chrome/browser/nostr/nsite/nsite_service.h
@@ -1,0 +1,65 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROME_BROWSER_NOSTR_NSITE_NSITE_SERVICE_H_
+#define CHROME_BROWSER_NOSTR_NSITE_NSITE_SERVICE_H_
+
+#include <memory>
+
+#include "base/functional/callback.h"
+#include "base/memory/singleton.h"
+#include "base/no_destructor.h"
+#include "base/synchronization/lock.h"
+#include "base/thread_annotations.h"
+#include "chrome/browser/profiles/profile.h"
+
+namespace nostr {
+
+class NsiteStreamingServer;
+
+// Singleton service managing the nsite streaming server
+class NsiteService {
+ public:
+  // Get the singleton instance
+  static NsiteService* GetInstance();
+
+  // Get or start the streaming server for a profile
+  // Returns the server port, or 0 on failure
+  uint16_t GetOrStartServer(Profile* profile);
+
+  // Stop the server for a profile
+  void StopServer(Profile* profile);
+
+  // Get the current server port (0 if not running)
+  uint16_t GetServerPort(Profile* profile);
+
+  // Check if server is running for a profile
+  bool IsServerRunning(Profile* profile);
+
+  // Callback for server state changes
+  using ServerStateCallback = base::RepeatingCallback<void(bool running, uint16_t port)>;
+  void AddServerStateObserver(ServerStateCallback callback);
+
+ private:
+  friend class base::NoDestructor<NsiteService>;
+  
+  NsiteService();
+  ~NsiteService();
+
+  // Thread-safe server management
+  struct ServerInfo {
+    std::unique_ptr<NsiteStreamingServer> server;
+    uint16_t port = 0;
+  };
+
+  base::Lock lock_;
+  std::map<Profile*, ServerInfo> servers_ GUARDED_BY(lock_);
+  std::vector<ServerStateCallback> observers_ GUARDED_BY(lock_);
+
+  void NotifyServerStateChange(bool running, uint16_t port);
+};
+
+}  // namespace nostr
+
+#endif  // CHROME_BROWSER_NOSTR_NSITE_NSITE_SERVICE_H_

--- a/src/chrome/browser/nostr/nsite/nsite_streaming_server.cc
+++ b/src/chrome/browser/nostr/nsite/nsite_streaming_server.cc
@@ -1,0 +1,306 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/nostr/nsite/nsite_streaming_server.h"
+
+#include <algorithm>
+#include <random>
+#include <set>
+
+#include "base/logging.h"
+#include "base/rand_util.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
+#include "base/task/thread_pool.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
+#include "net/base/io_buffer.h"
+#include "net/base/net_errors.h"
+#include "net/http/http_response_headers.h"
+#include "net/http/http_status_code.h"
+#include "net/socket/tcp_server_socket.h"
+
+namespace nostr {
+
+namespace {
+
+// Port allocation constants
+constexpr uint16_t kMinEphemeralPort = 49152;
+constexpr uint16_t kMaxEphemeralPort = 65535;
+constexpr int kMaxRandomAttempts = 100;
+constexpr int kMaxSequentialAttempts = 1000;
+
+// Common development ports to avoid
+const std::set<uint16_t> kBlacklistedPorts = {
+    3000,   // React dev server
+    3001,   // Create React App fallback
+    3333,   // Meteor
+    4200,   // Angular CLI
+    5000,   // Flask, serve
+    5173,   // Vite
+    5432,   // PostgreSQL
+    6379,   // Redis
+    7000,   // Cassandra
+    8000,   // Django, http-server
+    8080,   // Common HTTP proxy
+    8081,   // Common alternative HTTP
+    8082,   // Common alternative HTTP
+    8083,   // Common alternative HTTP
+    8888,   // Jupyter
+    9000,   // PHP-FPM, SonarQube
+    9200,   // Elasticsearch
+    9229,   // Node.js debugger
+    27017,  // MongoDB
+};
+
+// HTTP response templates
+constexpr char kErrorTemplate[] = R"(<!DOCTYPE html>
+<html>
+<head>
+<title>Error %d</title>
+<style>
+body { font-family: system-ui, sans-serif; margin: 40px; }
+h1 { color: #d73a49; }
+p { color: #586069; }
+</style>
+</head>
+<body>
+<h1>Error %d</h1>
+<p>%s</p>
+</body>
+</html>)";
+
+}  // namespace
+
+NsiteStreamingServer::NsiteStreamingServer(base::FilePath profile_path)
+    : profile_path_(std::move(profile_path)),
+      io_task_runner_(content::GetIOThreadTaskRunner({})) {
+  DCHECK(!profile_path_.empty());
+}
+
+NsiteStreamingServer::~NsiteStreamingServer() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  Stop();
+}
+
+uint16_t NsiteStreamingServer::Start() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  
+  if (IsRunning()) {
+    LOG(WARNING) << "Nsite streaming server already running on port " << port_;
+    return port_;
+  }
+
+  uint16_t allocated_port = AllocatePort();
+  if (allocated_port == 0) {
+    LOG(ERROR) << "Failed to allocate port for nsite streaming server";
+    return 0;
+  }
+
+  port_ = allocated_port;
+  LOG(INFO) << "Nsite streaming server started on port " << port_;
+  return port_;
+}
+
+void NsiteStreamingServer::Stop() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  
+  if (!IsRunning()) {
+    return;
+  }
+
+  server_.reset();
+  server_socket_.reset();
+  port_ = 0;
+  
+  LOG(INFO) << "Nsite streaming server stopped";
+}
+
+uint16_t NsiteStreamingServer::AllocatePort() {
+  // Try random allocation first
+  uint16_t port = TryRandomPorts();
+  if (port != 0) {
+    return port;
+  }
+
+  // Fall back to sequential scan
+  return TrySequentialPorts();
+}
+
+uint16_t NsiteStreamingServer::TryRandomPorts() {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<uint16_t> dist(kMinEphemeralPort, kMaxEphemeralPort);
+
+  for (int i = 0; i < kMaxRandomAttempts; ++i) {
+    uint16_t port = dist(gen);
+    if (!IsPortBlacklisted(port) && TryBindPort(port)) {
+      return port;
+    }
+  }
+
+  return 0;
+}
+
+uint16_t NsiteStreamingServer::TrySequentialPorts() {
+  // Start from a random offset to avoid always picking the same port
+  uint16_t offset = base::RandInt(0, kMaxEphemeralPort - kMinEphemeralPort);
+  
+  for (int i = 0; i < kMaxSequentialAttempts; ++i) {
+    uint16_t port = kMinEphemeralPort + ((offset + i) % (kMaxEphemeralPort - kMinEphemeralPort + 1));
+    if (!IsPortBlacklisted(port) && TryBindPort(port)) {
+      return port;
+    }
+  }
+
+  return 0;
+}
+
+bool NsiteStreamingServer::IsPortBlacklisted(uint16_t port) {
+  return kBlacklistedPorts.find(port) != kBlacklistedPorts.end();
+}
+
+bool NsiteStreamingServer::TryBindPort(uint16_t port) {
+  auto socket = std::make_unique<net::TCPServerSocket>(nullptr, net::NetLogSource());
+  
+  int result = socket->Listen(net::IPEndPoint(net::IPAddress::IPv4Localhost(), port), 5);
+  if (result != net::OK) {
+    return false;
+  }
+
+  // Successfully bound, create the HTTP server
+  server_socket_ = std::move(socket);
+  server_ = std::make_unique<net::HttpServer>(std::move(socket), this);
+  
+  return true;
+}
+
+void NsiteStreamingServer::OnConnect(int connection_id) {
+  // Connection established
+}
+
+void NsiteStreamingServer::OnHttpRequest(int connection_id,
+                                        const net::HttpServerRequestInfo& info) {
+  DCHECK(io_task_runner_->BelongsToCurrentThread());
+  
+  auto context = ParseNsiteRequest(info);
+  if (!context.valid) {
+    SendErrorResponse(connection_id, net::HTTP_BAD_REQUEST, 
+                     "Missing or invalid X-Nsite-Pubkey header");
+    return;
+  }
+
+  HandleNsiteRequest(connection_id, context);
+}
+
+void NsiteStreamingServer::OnWebSocketRequest(int connection_id,
+                                             const net::HttpServerRequestInfo& info) {
+  // WebSocket not supported for nsite streaming
+  server_->Send404(connection_id);
+}
+
+void NsiteStreamingServer::OnWebSocketMessage(int connection_id, 
+                                             std::string_view data) {
+  // Should not be called
+}
+
+void NsiteStreamingServer::OnClose(int connection_id) {
+  // Connection closed
+}
+
+NsiteStreamingServer::RequestContext NsiteStreamingServer::ParseNsiteRequest(
+    const net::HttpServerRequestInfo& info) {
+  RequestContext context;
+  
+  // Extract X-Nsite-Pubkey header (case-insensitive)
+  std::string npub;
+  for (const auto& header : info.headers) {
+    if (base::EqualsCaseInsensitiveASCII(header.first, "X-Nsite-Pubkey")) {
+      npub = header.second;
+      break;
+    }
+  }
+
+  if (npub.empty()) {
+    LOG(WARNING) << "Request missing X-Nsite-Pubkey header: " << info.path;
+    return context;
+  }
+
+  // Validate npub format (basic check)
+  if (!base::StartsWith(npub, "npub1") || npub.length() < 10) {
+    LOG(WARNING) << "Invalid npub format: " << npub;
+    return context;
+  }
+
+  context.npub = npub;
+  context.path = info.path;
+  context.valid = true;
+  
+  // Remove leading slash from path
+  if (!context.path.empty() && context.path[0] == '/') {
+    context.path = context.path.substr(1);
+  }
+
+  LOG(INFO) << "Nsite request: " << npub << " -> " << context.path;
+  
+  return context;
+}
+
+void NsiteStreamingServer::HandleNsiteRequest(int connection_id,
+                                             const RequestContext& context) {
+  // TODO: Implement actual file serving from cache
+  // For now, return a placeholder response
+  
+  std::string response = base::StringPrintf(
+      R"(<!DOCTYPE html>
+<html>
+<head>
+<title>Nsite: %s</title>
+<style>
+body { font-family: system-ui, sans-serif; margin: 40px; }
+h1 { color: #0366d6; }
+p { color: #586069; }
+.info { background: #f6f8fa; padding: 20px; border-radius: 6px; }
+code { background: #e1e4e8; padding: 2px 4px; border-radius: 3px; }
+</style>
+</head>
+<body>
+<h1>Nsite Streaming Server</h1>
+<div class="info">
+<p><strong>Nsite:</strong> <code>%s</code></p>
+<p><strong>Path:</strong> <code>%s</code></p>
+<p><strong>Status:</strong> Cache implementation pending</p>
+</div>
+</body>
+</html>)",
+      context.npub.c_str(),
+      context.npub.c_str(),
+      context.path.c_str());
+
+  scoped_refptr<net::HttpResponseHeaders> headers =
+      net::HttpResponseHeaders::TryToCreate("HTTP/1.1 200 OK\r\n\r\n");
+  headers->AddHeader("Content-Type", "text/html; charset=utf-8");
+  headers->AddHeader("Cache-Control", "no-cache");
+  
+  server_->SendResponse(connection_id, headers, response);
+}
+
+void NsiteStreamingServer::SendErrorResponse(int connection_id,
+                                            int status_code,
+                                            const std::string& message) {
+  std::string body = base::StringPrintf(kErrorTemplate, 
+                                       status_code, status_code, message.c_str());
+  
+  scoped_refptr<net::HttpResponseHeaders> headers =
+      net::HttpResponseHeaders::TryToCreate(
+          base::StringPrintf("HTTP/1.1 %d %s\r\n\r\n",
+                           status_code,
+                           net::GetHttpReasonPhrase(status_code)));
+  headers->AddHeader("Content-Type", "text/html; charset=utf-8");
+  
+  server_->SendResponse(connection_id, headers, body);
+}
+
+}  // namespace nostr

--- a/src/chrome/browser/nostr/nsite/nsite_streaming_server.h
+++ b/src/chrome/browser/nostr/nsite/nsite_streaming_server.h
@@ -1,0 +1,83 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROME_BROWSER_NOSTR_NSITE_NSITE_STREAMING_SERVER_H_
+#define CHROME_BROWSER_NOSTR_NSITE_NSITE_STREAMING_SERVER_H_
+
+#include <memory>
+#include <string>
+
+#include "base/memory/weak_ptr.h"
+#include "base/sequence_checker.h"
+#include "base/task/single_thread_task_runner.h"
+#include "net/base/ip_endpoint.h"
+#include "net/base/net_errors.h"
+#include "net/server/http_server.h"
+#include "net/server/http_server_request_info.h"
+#include "net/socket/server_socket.h"
+
+namespace nostr {
+
+// HTTP server for streaming nsite content with dynamic port allocation
+class NsiteStreamingServer : public net::HttpServer::Delegate {
+ public:
+  explicit NsiteStreamingServer(base::FilePath profile_path);
+  ~NsiteStreamingServer() override;
+
+  // Start the server on a dynamically allocated port
+  // Returns the allocated port on success, 0 on failure
+  uint16_t Start();
+
+  // Stop the server
+  void Stop();
+
+  // Check if server is running
+  bool IsRunning() const { return server_ != nullptr; }
+
+  // Get the server port (0 if not running)
+  uint16_t GetPort() const { return port_; }
+
+  // net::HttpServer::Delegate implementation
+  void OnConnect(int connection_id) override;
+  void OnHttpRequest(int connection_id,
+                     const net::HttpServerRequestInfo& info) override;
+  void OnWebSocketRequest(int connection_id,
+                         const net::HttpServerRequestInfo& info) override;
+  void OnWebSocketMessage(int connection_id, std::string_view data) override;
+  void OnClose(int connection_id) override;
+
+ private:
+  // Port allocation strategies
+  uint16_t AllocatePort();
+  uint16_t TryRandomPorts();
+  uint16_t TrySequentialPorts();
+  bool IsPortBlacklisted(uint16_t port);
+  bool TryBindPort(uint16_t port);
+
+  // Request handling
+  struct RequestContext {
+    std::string npub;
+    std::string path;
+    bool valid = false;
+  };
+
+  RequestContext ParseNsiteRequest(const net::HttpServerRequestInfo& info);
+  void HandleNsiteRequest(int connection_id, const RequestContext& context);
+  void SendErrorResponse(int connection_id, int status_code,
+                        const std::string& message);
+
+  base::FilePath profile_path_;
+  std::unique_ptr<net::HttpServer> server_;
+  std::unique_ptr<net::ServerSocket> server_socket_;
+  uint16_t port_ = 0;
+
+  scoped_refptr<base::SingleThreadTaskRunner> io_task_runner_;
+  
+  SEQUENCE_CHECKER(sequence_checker_);
+  base::WeakPtrFactory<NsiteStreamingServer> weak_factory_{this};
+};
+
+}  // namespace nostr
+
+#endif  // CHROME_BROWSER_NOSTR_NSITE_NSITE_STREAMING_SERVER_H_

--- a/src/chrome/browser/nostr/nsite/nsite_streaming_server_unittest.cc
+++ b/src/chrome/browser/nostr/nsite/nsite_streaming_server_unittest.cc
@@ -1,0 +1,203 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/nostr/nsite/nsite_streaming_server.h"
+
+#include <memory>
+#include <set>
+
+#include "base/files/scoped_temp_dir.h"
+#include "base/test/task_environment.h"
+#include "content/public/test/browser_task_environment.h"
+#include "net/base/net_errors.h"
+#include "net/http/http_status_code.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace nostr {
+
+class NsiteStreamingServerTest : public testing::Test {
+ protected:
+  NsiteStreamingServerTest()
+      : task_environment_(base::test::TaskEnvironment::MainThreadType::IO) {}
+
+  void SetUp() override {
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+    server_ = std::make_unique<NsiteStreamingServer>(temp_dir_.GetPath());
+  }
+
+  void TearDown() override {
+    server_.reset();
+  }
+
+  content::BrowserTaskEnvironment task_environment_;
+  base::ScopedTempDir temp_dir_;
+  std::unique_ptr<NsiteStreamingServer> server_;
+};
+
+TEST_F(NsiteStreamingServerTest, StartStop) {
+  // Test starting the server
+  uint16_t port = server_->Start();
+  EXPECT_GT(port, 0);
+  EXPECT_GE(port, 49152);
+  EXPECT_LE(port, 65535);
+  EXPECT_TRUE(server_->IsRunning());
+  EXPECT_EQ(port, server_->GetPort());
+
+  // Test stopping the server
+  server_->Stop();
+  EXPECT_FALSE(server_->IsRunning());
+  EXPECT_EQ(0, server_->GetPort());
+}
+
+TEST_F(NsiteStreamingServerTest, DoubleStart) {
+  // Start server
+  uint16_t port1 = server_->Start();
+  EXPECT_GT(port1, 0);
+
+  // Try to start again - should return same port
+  uint16_t port2 = server_->Start();
+  EXPECT_EQ(port1, port2);
+  EXPECT_TRUE(server_->IsRunning());
+}
+
+TEST_F(NsiteStreamingServerTest, PortInEphemeralRange) {
+  uint16_t port = server_->Start();
+  EXPECT_GT(port, 0);
+  
+  // Check port is in ephemeral range
+  EXPECT_GE(port, 49152);
+  EXPECT_LE(port, 65535);
+}
+
+TEST_F(NsiteStreamingServerTest, AvoidBlacklistedPorts) {
+  // Start multiple servers to increase chance of hitting different ports
+  std::set<uint16_t> allocated_ports;
+  const std::set<uint16_t> blacklisted = {
+      3000, 3001, 3333, 4200, 5000, 5173, 5432, 6379,
+      7000, 8000, 8080, 8081, 8082, 8083, 8888, 9000,
+      9200, 9229, 27017
+  };
+
+  for (int i = 0; i < 10; ++i) {
+    auto test_server = std::make_unique<NsiteStreamingServer>(temp_dir_.GetPath());
+    uint16_t port = test_server->Start();
+    
+    if (port > 0) {
+      // Ensure not in blacklist
+      EXPECT_EQ(blacklisted.find(port), blacklisted.end());
+      allocated_ports.insert(port);
+      test_server->Stop();
+    }
+  }
+
+  // Should have allocated at least one port
+  EXPECT_GT(allocated_ports.size(), 0u);
+}
+
+TEST_F(NsiteStreamingServerTest, ParseRequestMissingHeader) {
+  // Start server
+  uint16_t port = server_->Start();
+  ASSERT_GT(port, 0);
+
+  // Create request without X-Nsite-Pubkey header
+  net::HttpServerRequestInfo request;
+  request.method = "GET";
+  request.path = "/index.html";
+
+  // Parse should fail
+  auto context = server_->ParseNsiteRequest(request);
+  EXPECT_FALSE(context.valid);
+}
+
+TEST_F(NsiteStreamingServerTest, ParseRequestValidHeader) {
+  // Start server
+  uint16_t port = server_->Start();
+  ASSERT_GT(port, 0);
+
+  // Create request with valid header
+  net::HttpServerRequestInfo request;
+  request.method = "GET";
+  request.path = "/path/to/file.html";
+  request.headers["X-Nsite-Pubkey"] = "npub1234567890abcdef";
+
+  // Parse should succeed
+  auto context = server_->ParseNsiteRequest(request);
+  EXPECT_TRUE(context.valid);
+  EXPECT_EQ(context.npub, "npub1234567890abcdef");
+  EXPECT_EQ(context.path, "path/to/file.html");
+}
+
+TEST_F(NsiteStreamingServerTest, ParseRequestCaseInsensitiveHeader) {
+  // Start server
+  uint16_t port = server_->Start();
+  ASSERT_GT(port, 0);
+
+  // Create request with different case header
+  net::HttpServerRequestInfo request;
+  request.method = "GET";
+  request.path = "/test.js";
+  request.headers["x-nsite-pubkey"] = "npub1test";
+
+  // Parse should succeed (case-insensitive)
+  auto context = server_->ParseNsiteRequest(request);
+  EXPECT_TRUE(context.valid);
+  EXPECT_EQ(context.npub, "npub1test");
+}
+
+TEST_F(NsiteStreamingServerTest, ParseRequestInvalidNpub) {
+  // Start server
+  uint16_t port = server_->Start();
+  ASSERT_GT(port, 0);
+
+  // Create request with invalid npub (doesn't start with npub1)
+  net::HttpServerRequestInfo request;
+  request.method = "GET";
+  request.path = "/index.html";
+  request.headers["X-Nsite-Pubkey"] = "invalid";
+
+  // Parse should fail
+  auto context = server_->ParseNsiteRequest(request);
+  EXPECT_FALSE(context.valid);
+}
+
+TEST_F(NsiteStreamingServerTest, MultipleServerInstances) {
+  // Create multiple servers with different profiles
+  base::ScopedTempDir temp_dir2;
+  ASSERT_TRUE(temp_dir2.CreateUniqueTempDir());
+  
+  auto server2 = std::make_unique<NsiteStreamingServer>(temp_dir2.GetPath());
+
+  // Both should start on different ports
+  uint16_t port1 = server_->Start();
+  uint16_t port2 = server2->Start();
+
+  EXPECT_GT(port1, 0);
+  EXPECT_GT(port2, 0);
+  EXPECT_NE(port1, port2);
+
+  EXPECT_TRUE(server_->IsRunning());
+  EXPECT_TRUE(server2->IsRunning());
+
+  // Clean up
+  server2->Stop();
+}
+
+TEST_F(NsiteStreamingServerTest, ServerRestartNewPort) {
+  // Start server
+  uint16_t port1 = server_->Start();
+  EXPECT_GT(port1, 0);
+
+  // Stop and restart
+  server_->Stop();
+  uint16_t port2 = server_->Start();
+  EXPECT_GT(port2, 0);
+
+  // Port might be the same or different, both are valid
+  // Just verify it's in the valid range
+  EXPECT_GE(port2, 49152);
+  EXPECT_LE(port2, 65535);
+}
+
+}  // namespace nostr


### PR DESCRIPTION
Fixes #78

## Summary
- Implemented NsiteStreamingServer with dynamic port allocation in ephemeral range (49152-65535)
- Created NsiteService singleton for managing server lifecycle across profiles
- Added comprehensive unit tests for port allocation and request parsing

## Key Changes
1. **Port Allocation Logic**:
   - Random port selection in ephemeral range (49152-65535)
   - Blacklist of common development ports (3000, 8080, 5173, etc.)
   - Fallback to sequential scan if random selection fails

2. **Header-Based Routing**:
   - Parse X-Nsite-Pubkey header from incoming requests
   - Case-insensitive header matching
   - Validate npub format

3. **Server Management**:
   - NsiteService singleton manages per-profile servers
   - Thread-safe access to server port information
   - Server state observers for UI updates

## Testing
- Unit tests verify port allocation avoids blacklisted ports
- Tests for header parsing with various scenarios
- Tests for multiple server instances and lifecycle management

## Next Steps
This PR implements the foundation for the streaming server. Follow-up PRs will add:
- D-8: Complete request routing implementation
- D-9: Cache manager for serving files
- D-10: Browser header injection system