### PR TITLE
[Issue D-8] Implement Header-Based Request Routing

### DIFF
--- a/src/chrome/browser/nostr/nsite/nsite_streaming_server.h
+++ b/src/chrome/browser/nostr/nsite/nsite_streaming_server.h
@@ -5,6 +5,7 @@
 #ifndef CHROME_BROWSER_NOSTR_NSITE_NSITE_STREAMING_SERVER_H_
 #define CHROME_BROWSER_NOSTR_NSITE_NSITE_STREAMING_SERVER_H_
 
+#include <map>
 #include <memory>
 #include <string>
 
@@ -59,7 +60,9 @@ class NsiteStreamingServer : public net::HttpServer::Delegate {
   struct RequestContext {
     std::string npub;
     std::string path;
+    std::string session_id;
     bool valid = false;
+    bool from_session = false;
   };
 
   RequestContext ParseNsiteRequest(const net::HttpServerRequestInfo& info);
@@ -67,11 +70,19 @@ class NsiteStreamingServer : public net::HttpServer::Delegate {
   void SendErrorResponse(int connection_id, int status_code,
                         const std::string& message);
 
+  // Session management
+  std::string GetOrCreateSession(const net::HttpServerRequestInfo& info);
+  void UpdateSession(const std::string& session_id, const std::string& npub);
+  std::string GetNpubFromSession(const std::string& session_id);
+
   base::FilePath profile_path_;
   std::unique_ptr<net::HttpServer> server_;
   std::unique_ptr<net::ServerSocket> server_socket_;
   uint16_t port_ = 0;
 
+  // Session tracking: session_id -> npub
+  std::map<std::string, std::string> sessions_;
+  
   scoped_refptr<base::SingleThreadTaskRunner> io_task_runner_;
   
   SEQUENCE_CHECKER(sequence_checker_);


### PR DESCRIPTION
Fixes #79

## Summary
- Enhanced request parsing with proper npub validation
- Implemented session-based fallback for maintaining nsite context
- Added comprehensive unit tests for routing scenarios

## Key Changes
1. **Enhanced Npub Validation**:
   - Validates npub prefix (must start with "npub1")
   - Validates npub length (must be exactly 63 characters)
   - Clear error messages for invalid formats

2. **Session Management**:
   - Creates sessions with unique GUIDs
   - Stores npub per session for fallback
   - Sets secure cookies (HttpOnly, SameSite=Strict)
   - Updates session when npub changes

3. **Request Routing**:
   - Primary: Uses X-Nsite-Pubkey header
   - Fallback: Uses session-stored npub
   - Tracks whether npub came from session
   - Enhanced logging for debugging

## Testing
- Unit tests for npub validation edge cases
- Tests for session creation and persistence
- Tests for session fallback behavior
- Tests for session updates with different npubs

## Next Steps
This PR completes the request routing foundation. Follow-up PRs will add:
- D-9: Cache manager for actual file serving
- D-10: Browser header injection system